### PR TITLE
Expand sidenav on wider screens with toggle buttons

### DIFF
--- a/augment_module.html
+++ b/augment_module.html
@@ -120,7 +120,7 @@
 
         
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/changelog.html
+++ b/changelog.html
@@ -126,7 +126,7 @@
         
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none">
+                <span class="d-sm-none sidenav-header">
                     <h2 class="text-center">Table of Contents</h2><hr class="custom-hr">
                 </span>
                 <div class="toc">
@@ -148,7 +148,7 @@
         
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/changelog.html
+++ b/changelog.html
@@ -120,7 +120,8 @@
 
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3" onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
         

--- a/changelog.html
+++ b/changelog.html
@@ -149,7 +149,7 @@
         
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/changelog2023.html
+++ b/changelog2023.html
@@ -193,7 +193,7 @@
         
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 m-auto guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/changelog2023.html
+++ b/changelog2023.html
@@ -120,13 +120,14 @@
 
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3" onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
         
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none">
+                <span class="d-sm-none sidenav-header">
                     <h2 class="text-center">Table of Contents</h2><hr class="custom-hr">
                 </span>
                 <div class="toc">
@@ -193,7 +194,7 @@
         
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/common_resource.html
+++ b/common_resource.html
@@ -126,7 +126,7 @@
         
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
+                <span class="d-sm-none sidenav-header"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
                 <div class="toc">
                     <ol>
                         <li>
@@ -184,7 +184,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/common_resource.html
+++ b/common_resource.html
@@ -185,7 +185,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/common_resource.html
+++ b/common_resource.html
@@ -120,7 +120,8 @@
         
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3" onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
         

--- a/custom_css/guide_page.css
+++ b/custom_css/guide_page.css
@@ -125,6 +125,11 @@ a.none {
   color: auto;
 }
 
+.footer {
+  position: relative;
+  z-index: 1019;
+}
+
 .footer-style {
   padding: 4px;
   margin: 8px;
@@ -644,6 +649,32 @@ div.modifiedShipRowContainer {
   transition: 0.5s; /* 0.5 second transition effect to slide in the sidenav */
 }
 
+.sidenav.toggle {
+  width: 250px;
+}
+
+/* container-sm-9 is 75% width so breakpoint * 0.25 >= 250 */
+@media screen and (min-width: 1000px) {
+  .sidenav {
+    width: 250px;
+  }
+  .custom-sidenav-button {
+    display: none;
+  }
+  .sidenav-header {
+    display: inline !important;
+  }
+  .sidenav-header > h2 {
+    font-size: 1.7rem;
+  }
+}
+
+/* max breakpoint = 1320px (container max width) + 500px */
+@media screen and (min-width: 1000px) and (max-width: 1820px){
+  .guide-content-body {
+    margin-left: 250px;
+  }
+}
 
 /* Position and style the close button (top right corner) */
 /* .sidenav .closebtn {
@@ -685,6 +716,7 @@ div.modifiedShipRowContainer {
 }
 
 .custom-sidenav-button.toggle {
+  left: 250px;
   border: 2px solid pink;
   background-color: #363636;
   color: hsla(0,0%,100%,.9);

--- a/custom_css/guide_page.css
+++ b/custom_css/guide_page.css
@@ -653,29 +653,6 @@ div.modifiedShipRowContainer {
   width: 250px;
 }
 
-/* container-sm-9 is 75% width so breakpoint * 0.25 >= 250 */
-@media screen and (min-width: 1000px) {
-  .sidenav {
-    width: 250px;
-  }
-  .custom-sidenav-button {
-    display: none;
-  }
-  .sidenav-header {
-    display: inline !important;
-  }
-  .sidenav-header > h2 {
-    font-size: 1.7rem;
-  }
-}
-
-/* max breakpoint = 1320px (container max width) + 500px */
-@media screen and (min-width: 1000px) and (max-width: 1820px){
-  .guide-content-body {
-    margin-left: 250px;
-  }
-}
-
 /* Position and style the close button (top right corner) */
 /* .sidenav .closebtn {
   position: absolute;
@@ -720,6 +697,67 @@ div.modifiedShipRowContainer {
   border: 2px solid pink;
   background-color: #363636;
   color: hsla(0,0%,100%,.9);
+}
+
+#sidenavToggleDown {
+  display: none;
+}
+
+.custom-sidenav-button.toggle > #sidenavToggleUp {
+  display: none;
+}
+
+.custom-sidenav-button.toggle > #sidenavToggleDown {
+  display: inline-block;
+}
+
+/* container-sm-9 is 75% width so breakpoint * 0.25 >= 250 */
+@media screen and (min-width: 1000px) {
+  .sidenav-header {
+    display: inline !important;
+  }
+  .sidenav-header > h2 {
+    font-size: 1.7rem;
+  }
+
+  .sidenav {
+    width: 250px;
+  }
+  .custom-sidenav-button {
+    left: 250px;
+  }
+  .custom-sidenav-button > .d-sm-inline {
+    display: none !important;
+  }
+  #sidenavToggleUp {
+    display: none;
+  }
+  #sidenavToggleDown {
+    display: inline-block;
+  }
+
+  .sidenav.custom-sidenav-collapse {
+    width: 0;
+  }
+  .custom-sidenav-button.custom-sidenav-collapse {
+    left: 0;
+  }
+  .custom-sidenav-button.custom-sidenav-collapse > .d-sm-inline {
+    display: inline !important;
+  }
+  .custom-sidenav-button.custom-sidenav-collapse > #sidenavToggleUp {
+    display: inline-block;
+  }
+  .custom-sidenav-button.custom-sidenav-collapse > #sidenavToggleDown {
+    display: none;
+  }
+}
+
+/* max breakpoint = 1320px (container max width) + 500px */
+@media screen and (min-width: 1000px) and (max-width: 1820px){
+  .guide-content-body {
+    margin-left: 250px;
+  }
 }
 
 

--- a/custom_css/guide_page.css
+++ b/custom_css/guide_page.css
@@ -637,11 +637,11 @@ div.modifiedShipRowContainer {
 /* The side navigation menu */
 .sidenav {
   height: 100%; /* 100% Full-height */
-  width: 0; /* 0 width - change this with JavaScript */
+  width: 250px;
   position: fixed; /* Stay in place */
   z-index: 1; /* Stay on top */
   top: 56px; /* Stay at the top */
-  left: 0;
+  left: -250px;
   background-color: #111; /* Black*/
   overflow-x: hidden; /* Disable horizontal scroll */
   padding-top: 15px;
@@ -650,7 +650,7 @@ div.modifiedShipRowContainer {
 }
 
 .sidenav.toggle {
-  width: 250px;
+  left: 0;
 }
 
 /* Position and style the close button (top right corner) */
@@ -721,7 +721,7 @@ div.modifiedShipRowContainer {
   }
 
   .sidenav {
-    width: 250px;
+    left: 0;
   }
   .custom-sidenav-button {
     left: 250px;
@@ -737,7 +737,7 @@ div.modifiedShipRowContainer {
   }
 
   .sidenav.custom-sidenav-collapse {
-    width: 0;
+    left: -250px;
   }
   .custom-sidenav-button.custom-sidenav-collapse {
     left: 0;

--- a/custom_css/guide_page.css
+++ b/custom_css/guide_page.css
@@ -755,7 +755,7 @@ div.modifiedShipRowContainer {
 
 /* max breakpoint = 1320px (container max width) + 500px */
 @media screen and (min-width: 1000px) and (max-width: 1820px){
-  .guide-content-body {
+  #main.custom-sidenav-shift {
     margin-left: 250px;
   }
 }

--- a/custom_css/guide_page.css
+++ b/custom_css/guide_page.css
@@ -757,6 +757,11 @@ div.modifiedShipRowContainer {
 @media screen and (min-width: 1000px) and (max-width: 1820px){
   #main.custom-sidenav-shift {
     margin-left: 250px;
+    transition: 0.5s;
+  }
+
+  #main.custom-sidenav-shift.custom-sidenav-collapse {
+    margin-left: 12.5vw;
   }
 }
 

--- a/custom_js/guide_page.js
+++ b/custom_js/guide_page.js
@@ -28,29 +28,19 @@ slider.addEventListener('mouseleave', stopDragging, false);
 
 
 //SideNav
-function openNav() {
-  document.getElementById("sidenav").style.width = "250px";
-  document.getElementById("sidenavButton").style.left = "250px";
-}
-
-function closeNav() {
-  document.getElementById("sidenav").style.width = "0";
-  document.getElementById("sidenavButton").style.left = "0px";
-}
-
 function toggleFunction() {
-  var element = document.getElementById("sidenavButton");
+  var sidenav = document.getElementById("sidenav");
+  var sidenavButton = document.getElementById("sidenavButton");
   var icon = document.getElementById("sidenavToggle");
-  element.classList.toggle("toggle")
+  sidenav.classList.toggle("toggle");
+  sidenavButton.classList.toggle("toggle");
 
-  if (element.classList.contains("toggle")) {
-    openNav();
+  if (sidenavButton.classList.contains("toggle")) {
     icon.classList.remove("fa-angle-double-up");
     icon.classList.add("fa-angle-double-down");
   }
 
   else {
-    closeNav();
     icon.classList.add("fa-angle-double-up");
     icon.classList.remove("fa-angle-double-down");
   }

--- a/custom_js/guide_page.js
+++ b/custom_js/guide_page.js
@@ -31,10 +31,12 @@ slider.addEventListener('mouseleave', stopDragging, false);
 function toggleFunction() {
   var sidenav = document.getElementById("sidenav");
   var sidenavButton = document.getElementById("sidenavButton");
+  var main = document.getElementById("main");
 
   if (window.innerWidth >= 1000) {
     sidenav.classList.toggle("custom-sidenav-collapse");
     sidenavButton.classList.toggle("custom-sidenav-collapse");
+    main.classList.toggle("custom-sidenav-collapse");
 
     if (sidenav.classList.contains("toggle") && sidenav.classList.contains("custom-sidenav-collapse")) {
       sidenav.classList.remove("toggle");
@@ -49,6 +51,7 @@ function toggleFunction() {
     if (sidenav.classList.contains("custom-sidenav-collapse") && sidenav.classList.contains("toggle")) {
       sidenav.classList.remove("custom-sidenav-collapse");
       sidenavButton.classList.remove("custom-sidenav-collapse");
+      main.classList.remove("custom-sidenav-collapse");
     }
   }
 }

--- a/custom_js/guide_page.js
+++ b/custom_js/guide_page.js
@@ -31,18 +31,25 @@ slider.addEventListener('mouseleave', stopDragging, false);
 function toggleFunction() {
   var sidenav = document.getElementById("sidenav");
   var sidenavButton = document.getElementById("sidenavButton");
-  var icon = document.getElementById("sidenavToggle");
-  sidenav.classList.toggle("toggle");
-  sidenavButton.classList.toggle("toggle");
 
-  if (sidenavButton.classList.contains("toggle")) {
-    icon.classList.remove("fa-angle-double-up");
-    icon.classList.add("fa-angle-double-down");
+  if (window.innerWidth >= 1000) {
+    sidenav.classList.toggle("custom-sidenav-collapse");
+    sidenavButton.classList.toggle("custom-sidenav-collapse");
+
+    if (sidenav.classList.contains("toggle") && sidenav.classList.contains("custom-sidenav-collapse")) {
+      sidenav.classList.remove("toggle");
+      sidenavButton.classList.remove("toggle");
+    }
   }
-
+  
   else {
-    icon.classList.add("fa-angle-double-up");
-    icon.classList.remove("fa-angle-double-down");
+    sidenav.classList.toggle("toggle");
+    sidenavButton.classList.toggle("toggle");
+    
+    if (sidenav.classList.contains("custom-sidenav-collapse") && sidenav.classList.contains("toggle")) {
+      sidenav.classList.remove("custom-sidenav-collapse");
+      sidenavButton.classList.remove("custom-sidenav-collapse");
+    }
   }
 }
 

--- a/early_ship_recommendations.html
+++ b/early_ship_recommendations.html
@@ -126,7 +126,7 @@
         
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
+                <span class="d-sm-none sidenav-header"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
                 <div class="toc">
                     <ol>
                         <li>
@@ -154,7 +154,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/early_ship_recommendations.html
+++ b/early_ship_recommendations.html
@@ -155,7 +155,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/early_ship_recommendations.html
+++ b/early_ship_recommendations.html
@@ -120,7 +120,8 @@
 
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3" onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
         

--- a/equipment.html
+++ b/equipment.html
@@ -120,7 +120,7 @@
 
         
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/farming.html
+++ b/farming.html
@@ -126,7 +126,7 @@
 
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
+                <span class="d-sm-none sidenav-header"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
                 <div class="toc">
                     <ol>
                         <li>
@@ -218,7 +218,7 @@
 
         
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/farming.html
+++ b/farming.html
@@ -219,7 +219,7 @@
 
         
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/farming.html
+++ b/farming.html
@@ -120,7 +120,8 @@
 
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3" onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
 

--- a/fleetbuilding.html
+++ b/fleetbuilding.html
@@ -125,7 +125,7 @@
 
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
+                <span class="d-sm-none sidenav-header"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
                 <div class="toc">
                     <ol>
                         <li>
@@ -277,7 +277,7 @@
         
         
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/fleetbuilding.html
+++ b/fleetbuilding.html
@@ -119,7 +119,8 @@
 
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3"  onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
 

--- a/fleetbuilding.html
+++ b/fleetbuilding.html
@@ -278,7 +278,7 @@
         
         
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/newbie_tips.html
+++ b/newbie_tips.html
@@ -126,7 +126,7 @@
         
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
+                <span class="d-sm-none sidenav-header"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
                 <div class="toc">
                     <ol>
                         <li>
@@ -199,7 +199,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/newbie_tips.html
+++ b/newbie_tips.html
@@ -120,7 +120,8 @@
 
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3" onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
         

--- a/newbie_tips.html
+++ b/newbie_tips.html
@@ -200,7 +200,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/research.html
+++ b/research.html
@@ -141,7 +141,7 @@
 
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
+                <span class="d-sm-none sidenav-header"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
                 <div class="toc">
                     <ol>
                         <li>
@@ -243,7 +243,7 @@
 
         
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/research.html
+++ b/research.html
@@ -135,7 +135,8 @@
 
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3"  onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
 

--- a/research.html
+++ b/research.html
@@ -244,7 +244,7 @@
 
         
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/samvaluation.html
+++ b/samvaluation.html
@@ -126,7 +126,7 @@
         
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
+                <span class="d-sm-none sidenav-header"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
                 <div class="toc">
                     <ol>
                         <li>
@@ -311,7 +311,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/samvaluation.html
+++ b/samvaluation.html
@@ -312,7 +312,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/samvaluation.html
+++ b/samvaluation.html
@@ -120,7 +120,8 @@
         
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3" onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
         

--- a/shop_priority.html
+++ b/shop_priority.html
@@ -126,7 +126,7 @@
         
         <div id="sidenav" class="sidenav overflow-auto">
             <div class="container m-auto">
-                <span class="d-sm-none"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
+                <span class="d-sm-none sidenav-header"><h2 class="text-center">Table of Contents</h2><hr class="custom-hr"></span>
                 <div class="toc">
                     <ol>
                         <li>
@@ -178,7 +178,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/shop_priority.html
+++ b/shop_priority.html
@@ -179,7 +179,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body custom-sidenav-shift col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>

--- a/shop_priority.html
+++ b/shop_priority.html
@@ -120,7 +120,8 @@
 
         <!-- Table of Contents (SideNav) -->
         <button id="sidenavButton" class="btn custom-sidenav-button z-3" onclick="toggleFunction()">
-            <i id="sidenavToggle" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleUp" class="fa fa-angle-double-up"></i>
+            <i id="sidenavToggleDown" class="fa fa-angle-double-down"></i>
             <span class="d-none d-sm-inline">Table of Contents</span>
         </button>
         

--- a/tools.html
+++ b/tools.html
@@ -120,7 +120,7 @@
 
 
         <!-- Content -->
-        <div class="container mt-5 mt-sm-0 m-auto guide-content-body col-12 col-sm-9" id="main">
+        <div class="container mt-5 mt-sm-0 guide-content-body col-12 col-sm-9" id="main">
             
             <!-- Margin Buffer -->
             <div class="row mb-3"></div>


### PR DESCRIPTION
Pushing to test so you can see play with it first.

The logic for the toggle is quite messy to handle the sidenav state mostly with CSS instead of JS.  
I also moved the angle symbol switching to CSS and fixed sidenav width to 250px to reduce the weird repositioning when it's sliding in/out.